### PR TITLE
Alias ruby gem loadable_path to to_path

### DIFF
--- a/src/gem.rs
+++ b/src/gem.rs
@@ -300,6 +300,9 @@ module {module_name}
   def self.load(db)
     db.load_extension(self.loadable_path)
   end
+  class << self
+    alias_method :to_path, :loadable_path
+  end
 end
 
 "#


### PR DESCRIPTION
The sqlite3-ruby gem recently published an improvement to make it easier and more flexible to load extensions:

https://github.com/sparklemotion/sqlite3-ruby/pull/586

Ruby modules for SQLite extensions should implement the interface:

    interface _ExtensionSpecifier
      def to_path: () → String
    end

A complementary change in Rails takes advantage of this interface to integrate the primary configuration file with the new sqlite3-ruby interface for extension loading:

https://github.com/rails/rails/pull/53827

The gem template provided here already has a similar method:

    def loadable_path

The change proposed here is to modify the gem template to provide an alias to loadable_path as to_path.

    # example
    SqliteVec.to_path # => returns same result as loadable_path

As a result of this change, Ruby gems published with this tool will conform to the new interface supported in sqlite3-ruby and Rails.